### PR TITLE
Auto-hide dynamic text window

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -4411,8 +4411,8 @@ function GenericTrigger.GetAdditionalProperties(data, triggernum)
       local variables = GenericTrigger.GetTsuConditionVariables(data.id, triggernum)
       if (type(variables) == "table") then
         for var, varData in pairs(variables) do
-          if (type(varData) == "table") and varData.display then
-            props[var] = varData.display
+          if (type(varData) == "table") then
+            props[var] = varData.display or var
           end
         end
       end

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasInput.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasInput.lua
@@ -1,30 +1,32 @@
 if not WeakAuras.IsLibsOK() then return end
 
-local Type, Version = "WeakAurasInput", 1
+local Type, Version = "WeakAurasInput", 2
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
-local OnEditFocusGained = function(frame)
-  local self = frame.obj
-  local option = self.userdata.option
-  if option and option.callbacks and option.callbacks.OnEditFocusGained then
-    option.callbacks.OnEditFocusGained(self)
-  end
-end
+local eventCallbacks = {
+  OnEditFocusGained = "OnEditFocusGained",
+  OnEditFocusLost = "OnEditFocusLost",
+  OnEnterPressed = "OnEnterPressed",
+  OnShow = "OnShow"
+}
 
-local OnShow = function(frame)
+local function EventHandler(frame, event)
   local self = frame.obj
   local option = self.userdata.option
-  if option and option.callbacks and option.callbacks.OnShow then
-    option.callbacks.OnShow(self)
+  if option and option.callbacks and option.callbacks[event] then
+    option.callbacks[event](self)
   end
 end
 
 local function Constructor()
   local widget = AceGUI:Create("EditBox")
   widget.type = Type
-  widget.editbox:HookScript("OnEditFocusGained", OnEditFocusGained)
-  widget.editbox:HookScript("OnShow", OnShow)
+
+  for event, callback in pairs(eventCallbacks) do
+    widget.editbox:HookScript(event, function(frame) EventHandler(frame, callback) end)
+  end
+
   return widget
 end
 

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMultiLineEditBox.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMultiLineEditBox.lua
@@ -3,7 +3,7 @@ if not WeakAuras.IsLibsOK() then return end
 ---@class OptionsPrivate
 local OptionsPrivate = select(2, ...)
 
-local Type, Version = "WeakAurasMultiLineEditBox", 38
+local Type, Version = "WeakAurasMultiLineEditBox", 39
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then return end
 
@@ -77,10 +77,16 @@ local function OnCursorChanged(self, _, y, _, cursorHeight)                     
   end
 end
 
-local function OnEditFocusLost(self)                                             -- EditBox
-  self:HighlightText(0, 0)
-  self.obj:Fire("OnEditFocusLost")
-  self.obj.scrollFrame:EnableMouseWheel(false);
+local function OnEditFocusLost(frame)                                             -- EditBox
+  local self = frame.obj
+  frame:HighlightText(0, 0)
+  self:Fire("OnEditFocusLost")
+  self.scrollFrame:EnableMouseWheel(false);
+
+  local option = self.userdata.option
+  if option and option.callbacks and option.callbacks.OnEditFocusLost then
+    option.callbacks.OnEditFocusLost(self)
+  end
 end
 
 local function OnEnter(self)                                                     -- EditBox / ScrollFrame
@@ -189,6 +195,13 @@ local function OnEditFocusGained(frame)
   local option = frame.obj.userdata.option
   if option and option.callbacks and option.callbacks.OnEditFocusGained then
     option.callbacks.OnEditFocusGained(frame.obj)
+  end
+end
+
+local function OnEnterPressed(frame)
+  local option = frame.obj.userdata.option
+  if option and option.callbacks and option.callbacks.OnEnterPressed then
+    option.callbacks.OnEnterPressed(frame.obj)
   end
 end
 

--- a/WeakAurasOptions/ActionOptions.lua
+++ b/WeakAurasOptions/ActionOptions.lua
@@ -160,7 +160,13 @@ function OptionsPrivate.GetActionOptions(data)
         callbacks = {
           OnEditFocusGained = function(self)
             local widget = dynamicTextInputs["start_message_dest"]
-            OptionsPrivate.ToggleTextReplacements(data, true, widget)
+            OptionsPrivate.ToggleTextReplacements(data, widget, "OnEditFocusGained")
+          end,
+          OnEditFocusLost = function(self)
+            OptionsPrivate.ToggleTextReplacements(nil, "OnEditFocusLost")
+          end,
+          OnEnterPressed = function(self)
+            OptionsPrivate.ToggleTextReplacements(nil, "OnEnterPressed")
           end,
           OnShow = function(self)
             dynamicTextInputs["start_message_dest"] = self
@@ -177,7 +183,7 @@ function OptionsPrivate.GetActionOptions(data)
         hidden = function() return data.actions.start.message_type ~= "WHISPER" end,
         func = function()
           local widget = dynamicTextInputs["start_message_dest"]
-          OptionsPrivate.ToggleTextReplacements(data, nil, widget)
+          OptionsPrivate.ToggleTextReplacements(data, widget, "ToggleButton")
         end,
         imageWidth = 24,
         imageHeight = 24,
@@ -213,7 +219,13 @@ function OptionsPrivate.GetActionOptions(data)
         callbacks = {
           OnEditFocusGained = function(self)
             local widget = dynamicTextInputs["start_message"]
-            OptionsPrivate.ToggleTextReplacements(data, true, widget)
+            OptionsPrivate.ToggleTextReplacements(data, widget, "OnEditFocusGained")
+          end,
+          OnEditFocusLost = function(self)
+            OptionsPrivate.ToggleTextReplacements(nil, "OnEditFocusLost")
+          end,
+          OnEnterPressed = function(self)
+            OptionsPrivate.ToggleTextReplacements(nil, "OnEnterPressed")
           end,
           OnShow = function(self)
             dynamicTextInputs["start_message"] = self
@@ -229,7 +241,7 @@ function OptionsPrivate.GetActionOptions(data)
         disabled = function() return not data.actions.start.do_message end,
         func = function()
           local widget = dynamicTextInputs["start_message"]
-          OptionsPrivate.ToggleTextReplacements(data, nil, widget)
+          OptionsPrivate.ToggleTextReplacements(data, widget, "ToggleButton")
         end,
         imageWidth = 24,
         imageHeight = 24,
@@ -663,7 +675,13 @@ function OptionsPrivate.GetActionOptions(data)
         callbacks = {
           OnEditFocusGained = function(self)
             local widget = dynamicTextInputs["finish_message_dest"]
-            OptionsPrivate.ToggleTextReplacements(data, true, widget)
+            OptionsPrivate.ToggleTextReplacements(data, widget, "OnEditFocusGained")
+          end,
+          OnEditFocusLost = function(self)
+            OptionsPrivate.ToggleTextReplacements(nil, "OnEditFocusLost")
+          end,
+          OnEnterPressed = function(self)
+            OptionsPrivate.ToggleTextReplacements(nil, "OnEnterPressed")
           end,
           OnShow = function(self)
             dynamicTextInputs["finish_message_dest"] = self
@@ -680,7 +698,7 @@ function OptionsPrivate.GetActionOptions(data)
         hidden = function() return data.actions.finish.message_type ~= "WHISPER" end,
         func = function()
           local widget = dynamicTextInputs["finish_message_dest"]
-          OptionsPrivate.ToggleTextReplacements(data, nil, widget)
+          OptionsPrivate.ToggleTextReplacements(data, widget, "ToggleButton")
         end,
         imageWidth = 24,
         imageHeight = 24,
@@ -716,7 +734,13 @@ function OptionsPrivate.GetActionOptions(data)
         callbacks = {
           OnEditFocusGained = function(self)
             local widget = dynamicTextInputs["finish_message"]
-            OptionsPrivate.ToggleTextReplacements(data, true, widget)
+            OptionsPrivate.ToggleTextReplacements(data, widget, "OnEditFocusGained")
+          end,
+          OnEditFocusLost = function(self)
+            OptionsPrivate.ToggleTextReplacements(nil, "OnEditFocusLost")
+          end,
+          OnEnterPressed = function(self)
+            OptionsPrivate.ToggleTextReplacements(nil, "OnEnterPressed")
           end,
           OnShow = function(self)
             dynamicTextInputs["finish_message"] = self
@@ -732,7 +756,7 @@ function OptionsPrivate.GetActionOptions(data)
         disabled = function() return not data.actions.finish.do_message end,
         func = function()
           local widget = dynamicTextInputs["finish_message"]
-          OptionsPrivate.ToggleTextReplacements(data, nil, widget)
+          OptionsPrivate.ToggleTextReplacements(data, widget, "ToggleButton")
         end,
         imageWidth = 24,
         imageHeight = 24,

--- a/WeakAurasOptions/ConditionOptions.lua
+++ b/WeakAurasOptions/ConditionOptions.lua
@@ -972,7 +972,13 @@ local function addControlsForChange(args, order, data, conditionVariable, totalA
       callbacks = {
         OnEditFocusGained = function(self)
           local widget = dynamicTextInputs["condition" .. i .. "value" .. j .. "message dest"]
-          OptionsPrivate.ToggleTextReplacements(data, true, widget)
+          OptionsPrivate.ToggleTextReplacements(data, widget, "OnEditFocusGained")
+        end,
+        OnEditFocusLost = function(self)
+          OptionsPrivate.ToggleTextReplacements(nil, "OnEditFocusLost")
+        end,
+        OnEnterPressed = function(self)
+          OptionsPrivate.ToggleTextReplacements(nil, "OnEnterPressed")
         end,
         OnShow = function(self)
           dynamicTextInputs["condition" .. i .. "value" .. j .. "message dest"] = self
@@ -992,7 +998,7 @@ local function addControlsForChange(args, order, data, conditionVariable, totalA
       end,
       func = function()
         local widget = dynamicTextInputs["condition" .. i .. "value" .. j .. "message dest"]
-        OptionsPrivate.ToggleTextReplacements(data, nil, widget)
+        OptionsPrivate.ToggleTextReplacements(data, widget, "ToggleButton")
       end,
       imageWidth = 24,
       imageHeight = 24,
@@ -1049,7 +1055,13 @@ local function addControlsForChange(args, order, data, conditionVariable, totalA
       callbacks = {
         OnEditFocusGained = function(self)
           local widget = dynamicTextInputs["condition" .. i .. "value" .. j .. "message"]
-          OptionsPrivate.ToggleTextReplacements(data, true, widget)
+          OptionsPrivate.ToggleTextReplacements(data, widget, "OnEditFocusGained")
+        end,
+        OnEditFocusLost = function(self)
+          OptionsPrivate.ToggleTextReplacements(nil, "OnEditFocusLost")
+        end,
+        OnEnterPressed = function(self)
+          OptionsPrivate.ToggleTextReplacements(nil, "OnEnterPressed")
         end,
         OnShow = function(self)
           dynamicTextInputs["condition" .. i .. "value" .. j .. "message"] = self
@@ -1066,7 +1078,7 @@ local function addControlsForChange(args, order, data, conditionVariable, totalA
       order = order,
       func = function()
         local widget = dynamicTextInputs["condition" .. i .. "value" .. j .. "message"]
-        OptionsPrivate.ToggleTextReplacements(data, nil, widget)
+        OptionsPrivate.ToggleTextReplacements(data, widget, "ToggleButton")
       end,
       imageWidth = 24,
       imageHeight = 24,

--- a/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
+++ b/WeakAurasOptions/OptionsFrames/OptionsFrame.lua
@@ -897,14 +897,32 @@ function OptionsPrivate.CreateFrame()
   dynamicTextCodesFrame.label = dynamicTextCodesLabel
   dynamicTextCodesFrame:Hide()
 
-  function OptionsPrivate.ToggleTextReplacements(data, show, widget)
-    if show or not dynamicTextCodesFrame:IsShown() then
+  function OptionsPrivate.ToggleTextReplacements(data, widget, event)
+    -- This throttle prevents double toggling as a result from OnEditFocusLost
+    local currentTime = GetTime()
+    if event ~= "OnEditFocusGained"
+    and dynamicTextCodesFrame.lastCaller
+    and dynamicTextCodesFrame.lastCaller.event == "OnEditFocusLost"
+    and currentTime - dynamicTextCodesFrame.lastCaller.time < 0.1
+    and not (event == "OnEnterPressed" and dynamicTextCodesFrame:IsMouseOver())
+    then
+      return
+    end
+
+    dynamicTextCodesFrame.lastCaller = {
+      event = event,
+      time = currentTime,
+    }
+
+    if event == "OnEditFocusGained" or not dynamicTextCodesFrame:IsShown() then
       dynamicTextCodesFrame:Show()
       if OptionsPrivate.currentDynamicTextInput ~= widget then
         OptionsPrivate.UpdateTextReplacements(dynamicTextCodesFrame, data)
       end
       OptionsPrivate.currentDynamicTextInput = widget
-    else
+    elseif event == "OnEnterPressed" then
+      dynamicTextCodesFrame:Hide()
+    elseif not dynamicTextCodesFrame:IsMouseOver() then -- Prevents hiding when clicking inside the frame
       dynamicTextCodesFrame:Hide()
     end
   end

--- a/WeakAurasOptions/RegionOptions/Text.lua
+++ b/WeakAurasOptions/RegionOptions/Text.lua
@@ -46,7 +46,7 @@ local function createOptions(id, data)
     __order = 1,
     __dynamicTextCodes = function()
       local widget = dynamicTextInputs["displayText"]
-      OptionsPrivate.ToggleTextReplacements(data, nil, widget)
+      OptionsPrivate.ToggleTextReplacements(data, widget, "ToggleButton")
     end,
     displayText = {
       type = "input",
@@ -68,7 +68,10 @@ local function createOptions(id, data)
       callbacks = {
         OnEditFocusGained = function(self)
           local widget = dynamicTextInputs["displayText"]
-          OptionsPrivate.ToggleTextReplacements(data, true, widget)
+          OptionsPrivate.ToggleTextReplacements(data, widget, "OnEditFocusGained")
+        end,
+        OnEditFocusLost = function(self)
+          OptionsPrivate.ToggleTextReplacements(nil, nil, "OnEditFocusLost")
         end,
         OnShow = function(self)
           dynamicTextInputs["displayText"] = self

--- a/WeakAurasOptions/SubRegionOptions/SubText.lua
+++ b/WeakAurasOptions/SubRegionOptions/SubText.lua
@@ -62,7 +62,13 @@ local function createOptions(parentData, data, index, subIndex)
       callbacks = {
         OnEditFocusGained = function(self)
           local widget = dynamicTextInputs[subIndex]
-          OptionsPrivate.ToggleTextReplacements(parentData, true, widget)
+          OptionsPrivate.ToggleTextReplacements(parentData, widget, "OnEditFocusGained")
+        end,
+        OnEditFocusLost = function(self)
+          OptionsPrivate.ToggleTextReplacements(nil, nil, "OnEditFocusLost")
+        end,
+        OnEnterPressed = function(self)
+          OptionsPrivate.ToggleTextReplacements(nil, nil, "OnEnterPressed")
         end,
         OnShow = function(self)
           dynamicTextInputs[subIndex] = self
@@ -77,7 +83,7 @@ local function createOptions(parentData, data, index, subIndex)
       order = 11.1,
       func = function()
         local widget = dynamicTextInputs[subIndex]
-        OptionsPrivate.ToggleTextReplacements(parentData, nil, widget)
+        OptionsPrivate.ToggleTextReplacements(parentData, widget, "ToggleButton")
       end,
       imageWidth = 24,
       imageHeight = 24,


### PR DESCRIPTION
Automatically hide the window when input loses focus.

This PR also adds custom variables from TSU that have no `display` value to the list of available text replacements. In the case of no display value it falls back to the var's name
